### PR TITLE
Fix PHP notices when given an empty route

### DIFF
--- a/Tests/RouterTest.php
+++ b/Tests/RouterTest.php
@@ -250,7 +250,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 		return array(
 			array('', true, array(), false),
 			array('articles/4', true, array(), false),
-			array('', true, array(), true),
+			array('', false, array('controller' => 'DefaultController', 'vars' => array()), true),
 			array('login', false, array('controller' => 'LoginController', 'vars' => array()), true),
 			array('articles', false, array('controller' => 'ArticlesController', 'vars' => array()), true),
 			array('articles/4', false, array('controller' => 'ArticleController', 'vars' => array('article_id' => 4)), true),
@@ -317,6 +317,10 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 				array(
 				   'pattern' => 'content/*category/:article',
 				   'controller' => 'ArticleController'
+				),
+				array(
+					'pattern' => '/',
+					'controller' => 'DefaultController'
 				)
 			)
 		);

--- a/src/Router.php
+++ b/src/Router.php
@@ -109,13 +109,13 @@ class Router implements \Serializable
 				// Match a splat with no variable.
 				$regex[] = '.*';
 			}
-			elseif ($segment[0] == '*')
+			elseif (isset($segment[0]) && $segment[0] == '*')
 			{
 				// Match a splat and capture the data to a named variable.
 				$vars[] = substr($segment, 1);
 				$regex[] = '(.*)';
 			}
-			elseif ($segment[0] == '\\' && $segment[1] == '*')
+			elseif (isset($segment[0]) && $segment[0] == '\\' && $segment[1] == '*')
 			{
 				// Match an escaped splat segment.
 				$regex[] = '\*' . preg_quote(substr($segment, 2));
@@ -125,7 +125,7 @@ class Router implements \Serializable
 				// Match an unnamed variable without capture.
 				$regex[] = '([^/]*)';
 			}
-			elseif ($segment[0] == ':')
+			elseif (isset($segment[0]) && $segment[0] == ':')
 			{
 				// Match a named variable and capture the data.
 				$varName = substr($segment, 1);
@@ -134,7 +134,7 @@ class Router implements \Serializable
 				// Use the regex in the rules array if it has been defined.
 				$regex[] = array_key_exists($varName, $rules) ? '(' . $rules[$varName] . ')' : '([^/]*)';
 			}
-			elseif ($segment[0] == '\\' && $segment[1] == ':')
+			elseif (isset($segment[0]) && $segment[0] == '\\' && $segment[1] == ':')
 			{
 				// Match a segment with an escaped variable character prefix.
 				$regex[] = preg_quote(substr($segment, 1));


### PR DESCRIPTION
I don't know if this is the best or even correct fix, but in the web services project we need to get a match on an empty route, ie. "/", but the router currently throws a PHP notice on line 112 because $segment[0] is undefined at that point (because $segment is an empty string).

This PR stops the PHP notices but is there a better way?