### PR TITLE
[Feature] Default vars for a route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ vendor/
 composer.phar
 composer.lock
 phpunit.xml
+
+.idea/

--- a/Tests/RouterTest.php
+++ b/Tests/RouterTest.php
@@ -86,12 +86,14 @@ class RouterTest extends TestCase
 				array(
 					'regex' => chr(1) . '^login$' . chr(1),
 					'vars' => array(),
-					'controller' => 'login'
+					'controller' => 'login',
+					'defaults' => array()
 				),
 				array(
 					'regex' => chr(1) . '^requests/((\d+))$' . chr(1),
 					'vars' => array('request_id'),
-					'controller' => 'request'
+					'controller' => 'request',
+					'defaults' => array()
 				)
 			),
 			'PUT' => array(),
@@ -129,7 +131,40 @@ class RouterTest extends TestCase
 					array(
 						'regex' => chr(1) . '^foo$' . chr(1),
 						'vars' => array(),
-						'controller' => 'MyApplicationFoo'
+						'controller' => 'MyApplicationFoo',
+						'defaults' => array()
+					)
+				),
+				'PUT' => array(),
+				'POST' => array(),
+				'DELETE' => array(),
+				'HEAD' => array(),
+				'OPTIONS' => array(),
+				'TRACE' => array(),
+				'PATCH' => array()
+			),
+			'routes',
+			$this->instance
+		);
+	}
+
+	/**
+	 * @testdox  Ensure a route is added to the Router.
+	 *
+	 * @covers   Joomla\Router\Router::addRoute
+	 */
+	public function testAddRouteWithDefaults()
+	{
+		$this->instance->addRoute('GET', 'foo', 'MyApplicationFoo', [], ['default1' => 'foo']);
+
+		$this->assertAttributeEquals(
+			array(
+				'GET' => array(
+					array(
+						'regex' => chr(1) . '^foo$' . chr(1),
+						'vars' => array(),
+						'controller' => 'MyApplicationFoo',
+						'defaults' => ['default1' => 'foo']
 					)
 				),
 				'PUT' => array(),
@@ -179,7 +214,8 @@ class RouterTest extends TestCase
 				array(
 					'regex' => chr(1) . '^login$' . chr(1),
 					'vars' => array(),
-					'controller' => 'login'
+					'controller' => 'login',
+					'defaults' => array()
 				),
 				array(
 					'regex' => chr(1) . '^user/([^/]*)/((\d+))$' . chr(1),
@@ -187,12 +223,14 @@ class RouterTest extends TestCase
 						'name',
 						'id'
 					),
-					'controller' => 'UserController'
+					'controller' => 'UserController',
+					'defaults' => array()
 				),
 				array(
 					'regex' => chr(1) . '^requests/((\d+))$' . chr(1),
 					'vars' => array('request_id'),
-					'controller' => 'request'
+					'controller' => 'request',
+					'defaults' => array()
 				)
 			),
 			'PUT' => array(),
@@ -286,7 +324,19 @@ class RouterTest extends TestCase
 				false,
 				array('controller' => 'ArticleController', 'vars' => array('category' => 'cat-1/cat-2/cat-3', 'article' => 'article-1')),
 				true
-			)
+			),
+			array(
+				'default_option/4',
+				false,
+				array('controller' => 'ArticleController', 'vars' => array('article_id' => 4, 'option' => 'content')),
+				true
+			),
+			array(
+				'overriden_option/article/4',
+				false,
+				array('controller' => 'ArticleController', 'vars' => array('id' => 4, 'option' => 'content', 'view' => 'article')),
+				true
+			),
 		);
 	}
 
@@ -330,7 +380,22 @@ class RouterTest extends TestCase
 				array(
 					'pattern' => '/',
 					'controller' => 'DefaultController'
-				)
+				),
+				array(
+					'pattern' => 'default_option/:article_id',
+					'controller' => 'ArticleController',
+					'defaults' => [
+						'option' => 'content'
+					]
+				),
+				array(
+					'pattern' => 'overriden_option/:view/:id',
+					'controller' => 'ArticleController',
+					'defaults' => [
+						'option' => 'content',
+						'view' => 'category'
+					]
+				),
 			)
 		);
 	}

--- a/docs/custom-vars.md
+++ b/docs/custom-vars.md
@@ -1,0 +1,27 @@
+## How to Pass Extra Information from a Route to a Controller
+
+The Joomla Router allows parameters inside the defaults collection that don't have to match a placeholder in the route
+path. This means, you can use the defaults array to specify extra parameters that will then be accessible for use in
+your Request object or controller.
+
+```php
+use Joomla\Router\Router;
+
+$router = new Router;
+$router->addRoute(
+    'GET',
+    '/user/:id',
+    'UserController@show',
+    array(
+        'id' => '(\d+)'
+    ),
+    array(
+        'id': 0,
+        'username': 'Fred'
+    )
+);
+```
+
+
+As you can see, the username variable was never defined inside the route path, but you can still access its value from
+the return once the URL is parsed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,2 @@
 * [Overview](overview.md)
+* [Custom Variables](custom-vars.md)

--- a/src/Router.php
+++ b/src/Router.php
@@ -23,7 +23,8 @@ class Router implements \Serializable
 	 * Example: array(
 	 *     'regex' => $regex,
 	 *     'vars' => $vars,
-	 *     'controller' => $controller
+	 *     'controller' => $controller,
+	 *     'defaults' => $defaults,
 	 * )
 	 *
 	 * @var    array
@@ -62,19 +63,21 @@ class Router implements \Serializable
 	 * @param   string  $pattern     The route pattern to use for matching.
 	 * @param   mixed   $controller  The controller to map to the given pattern.
 	 * @param   array   $rules       An array of regex rules keyed using the named route variables.
+	 * @param   array   $defaults    An array of default values that are used when the URL is matched.
 	 *
 	 * @return  $this
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function addRoute($method, $pattern, $controller, array $rules = [])
+	public function addRoute($method, $pattern, $controller, array $rules = [], array $defaults = [])
 	{
 		list($regex, $vars) = $this->buildRegexAndVarList($pattern, $rules);
 
 		$this->routes[strtoupper($method)][] = [
 			'regex'      => $regex,
 			'vars'       => $vars,
-			'controller' => $controller
+			'controller' => $controller,
+			'defaults'   => $defaults
 		];
 
 		return $this;
@@ -178,11 +181,12 @@ class Router implements \Serializable
 				throw new \UnexpectedValueException('Route map must contain a controller variable.');
 			}
 
-			// If rules have been specified, add them as well.
+			// If defaults, rules have been specified, add them as well.
+			$defaults  = array_key_exists('defaults', $route) ? $route['defaults'] : [];
 			$rules  = array_key_exists('rules', $route) ? $route['rules'] : [];
 			$method = array_key_exists('method', $route) ? $route['method'] : 'GET';
 
-			$this->addRoute($method, $route['pattern'], $route['controller'], $rules);
+			$this->addRoute($method, $route['pattern'], $route['controller'], $rules, $defaults);
 		}
 
 		return $this;
@@ -217,7 +221,7 @@ class Router implements \Serializable
 			if (preg_match($rule['regex'], $route, $matches))
 			{
 				// If we have gotten this far then we have a positive match.
-				$vars = [];
+				$vars = $rule['defaults'];
 
 				foreach ($rule['vars'] as $i => $var)
 				{


### PR DESCRIPTION
### Summary of Changes
Allows setting default variables for a route in a similar approach to how symfony manages it (https://symfony.com/doc/current/routing/extra_information.html)

This is to help with webservices where we need to have extra information like the component name retrieved on a route match.

### Testing Instructions
See unit tests