### PR TITLE
[2.0] Use objects for defining route data

### DIFF
--- a/Tests/RouterTest.php
+++ b/Tests/RouterTest.php
@@ -85,8 +85,8 @@ class RouterTest extends TestCase
 
 		$rules = array(
 			'GET' => array(
-				new Route('GET', chr(1) . '^login$' . chr(1), 'login', [], []),
-				new Route('GET', chr(1) . '^requests/((\d+))$' . chr(1), 'request', ['request_id'], []),
+				new Route('GET', 'login', 'login', [], []),
+				new Route('GET', 'requests/:request_id', 'request', ['request_id' => '(\d+)'], []),
 			),
 			'PUT' => array(),
 			'POST' => array(),
@@ -197,9 +197,9 @@ class RouterTest extends TestCase
 
 		$rules = array(
 			'GET' => array(
-				new Route('GET', chr(1) . '^login$' . chr(1), 'login', [], []),
-				new Route('GET', chr(1) . '^user/([^/]*)/((\d+))$' . chr(1), 'UserController', ['name', 'id'], []),
-				new Route('GET', chr(1) . '^requests/((\d+))$' . chr(1), 'request', ['request_id'], []),
+				new Route('GET', 'login', 'login', [], []),
+				new Route('GET', 'user/:name/:id', 'UserController', ['id' => '(\d+)'], []),
+				new Route('GET', 'requests/:request_id', 'request', ['request_id' => '(\d+)'], []),
 			),
 			'PUT' => array(),
 			'POST' => array(),

--- a/Tests/RouterTest.php
+++ b/Tests/RouterTest.php
@@ -228,7 +228,7 @@ class RouterTest extends TestCase
 			array('', false, array('controller' => 'DefaultController', 'vars' => array()), true),
 			array('login', false, array('controller' => 'LoginController', 'vars' => array()), true),
 			array('articles', false, array('controller' => 'ArticlesController', 'vars' => array()), true),
-			array('articles/4', false, array('controller' => 'ArticleController', 'vars' => array('article_id' => '4')), true),
+			array('articles/4', false, array('controller' => 'ArticleController', 'vars' => array('article_id' => 4)), true),
 			array('articles/4/crap', true, array(), true),
 			array('test', true, array(), true),
 			array('test/foo', true, array(), true),
@@ -256,13 +256,13 @@ class RouterTest extends TestCase
 			array(
 				'default_option/4',
 				false,
-				array('controller' => 'ArticleController', 'vars' => array('article_id' => '4', 'option' => 'content')),
+				array('controller' => 'ArticleController', 'vars' => array('article_id' => 4, 'option' => 'content')),
 				true
 			),
 			array(
 				'overriden_option/article/4',
 				false,
-				array('controller' => 'ArticleController', 'vars' => array('id' => '4', 'option' => 'content', 'view' => 'article')),
+				array('controller' => 'ArticleController', 'vars' => array('id' => 4, 'option' => 'content', 'view' => 'article')),
 				true
 			),
 		);

--- a/Tests/RouterTest.php
+++ b/Tests/RouterTest.php
@@ -7,6 +7,7 @@
 namespace Joomla\Router\Tests;
 
 use Joomla\Router\Exception\RouteNotFoundException;
+use Joomla\Router\Route;
 use Joomla\Router\Router;
 use PHPUnit\Framework\TestCase;
 
@@ -84,18 +85,8 @@ class RouterTest extends TestCase
 
 		$rules = array(
 			'GET' => array(
-				array(
-					'regex' => chr(1) . '^login$' . chr(1),
-					'vars' => array(),
-					'controller' => 'login',
-					'defaults' => array()
-				),
-				array(
-					'regex' => chr(1) . '^requests/((\d+))$' . chr(1),
-					'vars' => array('request_id'),
-					'controller' => 'request',
-					'defaults' => array()
-				)
+				new Route('GET', chr(1) . '^login$' . chr(1), 'login', [], []),
+				new Route('GET', chr(1) . '^requests/((\d+))$' . chr(1), 'request', ['request_id'], []),
 			),
 			'PUT' => array(),
 			'POST' => array(),
@@ -124,17 +115,14 @@ class RouterTest extends TestCase
 	 */
 	public function testAddRoute()
 	{
-		$this->instance->addRoute('GET', 'foo', 'MyApplicationFoo');
+		$route = new Route('GET', chr(1) . '^foo$' . chr(1), 'MyApplicationFoo', [], []);
+
+		$this->instance->addRoute($route);
 
 		$this->assertAttributeEquals(
 			array(
 				'GET' => array(
-					array(
-						'regex' => chr(1) . '^foo$' . chr(1),
-						'vars' => array(),
-						'controller' => 'MyApplicationFoo',
-						'defaults' => array()
-					)
+					$route
 				),
 				'PUT' => array(),
 				'POST' => array(),
@@ -156,17 +144,14 @@ class RouterTest extends TestCase
 	 */
 	public function testAddRouteWithDefaults()
 	{
-		$this->instance->addRoute('GET', 'foo', 'MyApplicationFoo', [], ['default1' => 'foo']);
+		$route = new Route('GET', chr(1) . '^foo$' . chr(1), 'MyApplicationFoo', [], ['default1' => 'foo']);
+
+		$this->instance->addRoute($route);
 
 		$this->assertAttributeEquals(
 			array(
 				'GET' => array(
-					array(
-						'regex' => chr(1) . '^foo$' . chr(1),
-						'vars' => array(),
-						'controller' => 'MyApplicationFoo',
-						'defaults' => ['default1' => 'foo']
-					)
+					$route
 				),
 				'PUT' => array(),
 				'POST' => array(),
@@ -212,27 +197,9 @@ class RouterTest extends TestCase
 
 		$rules = array(
 			'GET' => array(
-				array(
-					'regex' => chr(1) . '^login$' . chr(1),
-					'vars' => array(),
-					'controller' => 'login',
-					'defaults' => array()
-				),
-				array(
-					'regex' => chr(1) . '^user/([^/]*)/((\d+))$' . chr(1),
-					'vars' => array(
-						'name',
-						'id'
-					),
-					'controller' => 'UserController',
-					'defaults' => array()
-				),
-				array(
-					'regex' => chr(1) . '^requests/((\d+))$' . chr(1),
-					'vars' => array('request_id'),
-					'controller' => 'request',
-					'defaults' => array()
-				)
+				new Route('GET', chr(1) . '^login$' . chr(1), 'login', [], []),
+				new Route('GET', chr(1) . '^user/([^/]*)/((\d+))$' . chr(1), 'UserController', ['name', 'id'], []),
+				new Route('GET', chr(1) . '^requests/((\d+))$' . chr(1), 'request', ['request_id'], []),
 			),
 			'PUT' => array(),
 			'POST' => array(),

--- a/Tests/RouterTest.php
+++ b/Tests/RouterTest.php
@@ -276,7 +276,8 @@ class RouterTest extends TestCase
 		$actual = $this->instance->parseRoute($r);
 
 		// Test the assertions.
-		$this->assertEquals($i, $actual, 'Incorrect value returned.');
+		$this->assertSame($i['controller'], $actual->getController());
+		$this->assertEquals($i['vars'], $actual->getRouteVariables());
 	}
 
 	/**
@@ -310,7 +311,7 @@ class RouterTest extends TestCase
 			array('', false, array('controller' => 'DefaultController', 'vars' => array()), true),
 			array('login', false, array('controller' => 'LoginController', 'vars' => array()), true),
 			array('articles', false, array('controller' => 'ArticlesController', 'vars' => array()), true),
-			array('articles/4', false, array('controller' => 'ArticleController', 'vars' => array('article_id' => 4)), true),
+			array('articles/4', false, array('controller' => 'ArticleController', 'vars' => array('article_id' => '4')), true),
 			array('articles/4/crap', true, array(), true),
 			array('test', true, array(), true),
 			array('test/foo', true, array(), true),
@@ -338,13 +339,13 @@ class RouterTest extends TestCase
 			array(
 				'default_option/4',
 				false,
-				array('controller' => 'ArticleController', 'vars' => array('article_id' => 4, 'option' => 'content')),
+				array('controller' => 'ArticleController', 'vars' => array('article_id' => '4', 'option' => 'content')),
 				true
 			),
 			array(
 				'overriden_option/article/4',
 				false,
-				array('controller' => 'ArticleController', 'vars' => array('id' => 4, 'option' => 'content', 'view' => 'article')),
+				array('controller' => 'ArticleController', 'vars' => array('id' => '4', 'option' => 'content', 'view' => 'article')),
 				true
 			),
 		);

--- a/Tests/RouterTest.php
+++ b/Tests/RouterTest.php
@@ -115,7 +115,7 @@ class RouterTest extends TestCase
 	 */
 	public function testAddRoute()
 	{
-		$route = new Route('GET', chr(1) . '^foo$' . chr(1), 'MyApplicationFoo', [], []);
+		$route = new Route('GET', 'foo', 'MyApplicationFoo', [], []);
 
 		$this->instance->addRoute($route);
 
@@ -144,7 +144,7 @@ class RouterTest extends TestCase
 	 */
 	public function testAddRouteWithDefaults()
 	{
-		$route = new Route('GET', chr(1) . '^foo$' . chr(1), 'MyApplicationFoo', [], ['default1' => 'foo']);
+		$route = new Route('GET', 'foo', 'MyApplicationFoo', [], ['default1' => 'foo']);
 
 		$this->instance->addRoute($route);
 

--- a/Tests/RouterTest.php
+++ b/Tests/RouterTest.php
@@ -40,23 +40,9 @@ class RouterTest extends TestCase
 	 */
 	public function test__construct()
 	{
-		$emptyRoutes = array(
-			'GET' => array(),
-			'PUT' => array(),
-			'POST' => array(),
-			'DELETE' => array(),
-			'HEAD' => array(),
-			'OPTIONS' => array(),
-			'TRACE' => array(),
-			'PATCH' => array()
-		);
-
-		$router = new Router;
-
-		$this->assertAttributeEquals(
-			$emptyRoutes,
+		$this->assertAttributeEmpty(
 			'routes',
-			$router,
+			new Router,
 			'A Router should have no known routes by default.'
 		);
 	}
@@ -84,17 +70,8 @@ class RouterTest extends TestCase
 		);
 
 		$rules = array(
-			'GET' => array(
-				new Route('GET', 'login', 'login', [], []),
-				new Route('GET', 'requests/:request_id', 'request', ['request_id' => '(\d+)'], []),
-			),
-			'PUT' => array(),
-			'POST' => array(),
-			'DELETE' => array(),
-			'HEAD' => array(),
-			'OPTIONS' => array(),
-			'TRACE' => array(),
-			'PATCH' => array()
+			new Route(['GET'], 'login', 'login', [], []),
+			new Route(['GET'], 'requests/:request_id', 'request', ['request_id' => '(\d+)'], []),
 		);
 
 		$router = new Router($routes);
@@ -115,22 +92,13 @@ class RouterTest extends TestCase
 	 */
 	public function testAddRoute()
 	{
-		$route = new Route('GET', 'foo', 'MyApplicationFoo', [], []);
+		$route = new Route(['GET'], 'foo', 'MyApplicationFoo', [], []);
 
 		$this->instance->addRoute($route);
 
 		$this->assertAttributeEquals(
 			array(
-				'GET' => array(
-					$route
-				),
-				'PUT' => array(),
-				'POST' => array(),
-				'DELETE' => array(),
-				'HEAD' => array(),
-				'OPTIONS' => array(),
-				'TRACE' => array(),
-				'PATCH' => array()
+				$route,
 			),
 			'routes',
 			$this->instance
@@ -144,22 +112,13 @@ class RouterTest extends TestCase
 	 */
 	public function testAddRouteWithDefaults()
 	{
-		$route = new Route('GET', 'foo', 'MyApplicationFoo', [], ['default1' => 'foo']);
+		$route = new Route(['GET'], 'foo', 'MyApplicationFoo', [], ['default1' => 'foo']);
 
 		$this->instance->addRoute($route);
 
 		$this->assertAttributeEquals(
 			array(
-				'GET' => array(
-					$route
-				),
-				'PUT' => array(),
-				'POST' => array(),
-				'DELETE' => array(),
-				'HEAD' => array(),
-				'OPTIONS' => array(),
-				'TRACE' => array(),
-				'PATCH' => array()
+				$route,
 			),
 			'routes',
 			$this->instance
@@ -196,18 +155,9 @@ class RouterTest extends TestCase
 		);
 
 		$rules = array(
-			'GET' => array(
-				new Route('GET', 'login', 'login', [], []),
-				new Route('GET', 'user/:name/:id', 'UserController', ['id' => '(\d+)'], []),
-				new Route('GET', 'requests/:request_id', 'request', ['request_id' => '(\d+)'], []),
-			),
-			'PUT' => array(),
-			'POST' => array(),
-			'DELETE' => array(),
-			'HEAD' => array(),
-			'OPTIONS' => array(),
-			'TRACE' => array(),
-			'PATCH' => array()
+			new Route(['GET'], 'login', 'login', [], []),
+			new Route(['GET'], 'user/:name/:id', 'UserController', ['id' => '(\d+)'], []),
+			new Route(['GET'], 'requests/:request_id', 'request', ['request_id' => '(\d+)'], []),
 		);
 
 		$this->instance->addRoutes($routes);

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,2 +1,3 @@
 * [Overview](overview.md)
+* [Updating from v1 to v2](v1-to-v2-update.md)
 * [Custom Variables](custom-vars.md)

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -1,0 +1,11 @@
+## Updating from v1 to v2
+
+The following changes were made to the Router package between v1 and v2.
+
+### Minimum supported PHP version raised
+
+All Framework packages now require PHP 7.0 or newer.
+
+### Return value of `Joomla\Router\Router::parseRoute()` changed
+
+The `Joomla\Router\Router::parseRoute()` method has been changed to return a `Joomla\Router\ResolvedRoute` object instead of an array.

--- a/src/ResolvedRoute.php
+++ b/src/ResolvedRoute.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Part of the Joomla Framework Router Package
+ *
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Router;
+
+/**
+ * An object representing a resolved route.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ResolvedRoute
+{
+	/**
+	 * The controller which handles this route
+	 *
+	 * @var    mixed
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $controller;
+
+	/**
+	 * The variables matched by the route
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $routeVariables;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   mixed  $controller      The controller which handles this route
+	 * @param   array  $routeVariables  The variables matched by the route
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct($controller, array $routeVariables)
+	{
+		$this->controller     = $controller;
+		$this->routeVariables = $routeVariables;
+	}
+
+	/**
+	 * Retrieve the controller which handles this route
+	 *
+	 * @return  mixed
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getController()
+	{
+		return $this->controller;
+	}
+
+	/**
+	 * Retrieve the variables matched by the route
+	 *
+	 * @return  mixed
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getRouteVariables(): array
+	{
+		return $this->routeVariables;
+	}
+}

--- a/src/ResolvedRoute.php
+++ b/src/ResolvedRoute.php
@@ -32,17 +32,27 @@ class ResolvedRoute
 	private $routeVariables;
 
 	/**
+	 * The URI for this route
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $uri;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param   mixed  $controller      The controller which handles this route
-	 * @param   array  $routeVariables  The variables matched by the route
+	 * @param   mixed   $controller      The controller which handles this route
+	 * @param   array   $routeVariables  The variables matched by the route
+	 * @param   string  $uri             The URI for this route
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function __construct($controller, array $routeVariables)
+	public function __construct($controller, array $routeVariables, string $uri)
 	{
 		$this->controller     = $controller;
 		$this->routeVariables = $routeVariables;
+		$this->uri            = $uri;
 	}
 
 	/**
@@ -67,5 +77,17 @@ class ResolvedRoute
 	public function getRouteVariables(): array
 	{
 		return $this->routeVariables;
+	}
+
+	/**
+	 * Retrieve the URI for this route
+	 *
+	 * @return  mixed
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getUri(): string
+	{
+		return $this->uri;
 	}
 }

--- a/src/Route.php
+++ b/src/Route.php
@@ -96,9 +96,6 @@ class Route implements \Serializable
 	/**
 	 * Parse the route's pattern to extract the named variables and build a proper regular expression for use when parsing the routes.
 	 *
-	 * @param   string  $pattern  The route pattern to use for matching.
-	 * @param   array   $rules    An array of regex rules keyed using the named route variables.
-	 *
 	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__

--- a/src/Route.php
+++ b/src/Route.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Part of the Joomla Framework Router Package
+ *
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Router;
+
+use Jeremeamia\SuperClosure\SerializableClosure;
+
+/**
+ * An object representing a route definition.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class Route implements \Serializable
+{
+	/**
+	 * The controller which handles this route
+	 *
+	 * @var    mixed
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $controller;
+
+	/**
+	 * The default variables defined by the route
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $defaults = [];
+
+	/**
+	 * The HTTP method this route supports
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $method;
+
+	/**
+	 * The path regex this route processes
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $regex;
+
+	/**
+	 * The variables defined by the route
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $routeVariables = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   string  $method          The HTTP method this route supports
+	 * @param   string  $regex           The path regex this route processes
+	 * @param   mixed   $controller      The controller which handles this route
+	 * @param   array   $routeVariables  The variables defined by the route
+	 * @param   array   $defaults        The default variables defined by the route
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(string $method, string $regex, $controller, array $routeVariables = [], array $defaults = [])
+	{
+		$this->setMethod($method);
+		$this->setRegex($regex);
+		$this->setController($controller);
+		$this->setRouteVariables($routeVariables);
+		$this->setDefaults($defaults);
+	}
+
+	/**
+	 * Retrieve the controller which handles this route
+	 *
+	 * @return  mixed
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getController()
+	{
+		return $this->controller;
+	}
+
+	/**
+	 * Retrieve the default variables defined by the route
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getDefaults(): array
+	{
+		return $this->defaults;
+	}
+
+	/**
+	 * Retrieve the HTTP method this route supports
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMethod(): string
+	{
+		return $this->method;
+	}
+
+	/**
+	 * Retrieve the path regex this route processes
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getRegex(): string
+	{
+		return $this->regex;
+	}
+
+	/**
+	 * Retrieve the variables defined by the route
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getRouteVariables(): array
+	{
+		return $this->routeVariables;
+	}
+
+	/**
+	 * Set the controller which handles this route
+	 *
+	 * @param   mixed  $controller  The controller which handles this route
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setController($controller): self
+	{
+		$this->controller = $controller;
+
+		return $this;
+	}
+
+	/**
+	 * Set the default variables defined by the route
+	 *
+	 * @param   array  $defaults  The default variables defined by the route
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setDefaults(array $defaults): self
+	{
+		$this->defaults = $defaults;
+
+		return $this;
+	}
+
+	/**
+	 * Set the HTTP method this route supports
+	 *
+	 * @param   string  $method  The HTTP method this route supports
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setMethod(string $method): self
+	{
+		$this->method = strtoupper($method);
+
+		return $this;
+	}
+
+	/**
+	 * Set the path regex this route processes
+	 *
+	 * @param   string  $regex  The path regex this route processes
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setRegex(string $regex): self
+	{
+		$this->regex = $regex;
+
+		return $this;
+	}
+
+	/**
+	 * Set the variables defined by the route
+	 *
+	 * @param   array  $routeVariables  The variables defined by the route
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setRouteVariables(array $routeVariables): self
+	{
+		$this->routeVariables = $routeVariables;
+
+		return $this;
+	}
+
+	/**
+	 * String representation of the Router object
+	 *
+	 * @return  string  The string representation of the object or null
+	 *
+	 * @link    http://php.net/manual/en/serializable.serialize.php
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function serialize()
+	{
+		$controller = $this->getController() instanceof \Closure ? new SerializableClosure($this->getController()) : $this->getController();
+
+		return serialize(
+			[
+				'controller'     => $controller,
+				'defaults'       => $this->getDefaults(),
+				'method'         => $this->getMethod(),
+				'regex'          => $this->getRegex(),
+				'routeVariables' => $this->getRouteVariables(),
+			]
+		);
+	}
+
+	/**
+	 * Constructs the object from a serialized string
+	 *
+	 * @param   string  $serialized  The string representation of the object.
+	 *
+	 * @return  void
+	 *
+	 * @link    http://php.net/manual/en/serializable.unserialize.php
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function unserialize($serialized)
+	{
+		list ($this->controller, $this->defaults, $this->method, $this->regex, $this->routeVariables) = unserialize($serialized);
+	}
+}

--- a/src/Route.php
+++ b/src/Route.php
@@ -34,12 +34,12 @@ class Route implements \Serializable
 	private $defaults = [];
 
 	/**
-	 * The HTTP method this route supports
+	 * The HTTP methods this route supports
 	 *
-	 * @var    string
+	 * @var    string[]
 	 * @since  __DEPLOY_VERSION__
 	 */
-	private $method;
+	private $methods;
 
 	/**
 	 * The route pattern to use for matching
@@ -76,7 +76,7 @@ class Route implements \Serializable
 	/**
 	 * Constructor.
 	 *
-	 * @param   string  $method      The HTTP method this route supports
+	 * @param   array   $methods     The HTTP methods this route supports
 	 * @param   string  $pattern     The route pattern to use for matching
 	 * @param   mixed   $controller  The controller which handles this route
 	 * @param   array   $rules       An array of regex rules keyed using the route variables
@@ -84,9 +84,9 @@ class Route implements \Serializable
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function __construct(string $method, string $pattern, $controller, array $rules = [], array $defaults = [])
+	public function __construct(array $methods, string $pattern, $controller, array $rules = [], array $defaults = [])
 	{
-		$this->setMethod($method);
+		$this->setMethods($methods);
 		$this->setPattern($pattern);
 		$this->setController($controller);
 		$this->setRules($rules);
@@ -188,15 +188,15 @@ class Route implements \Serializable
 	}
 
 	/**
-	 * Retrieve the HTTP method this route supports
+	 * Retrieve the HTTP methods this route supports
 	 *
-	 * @return  string
+	 * @return  string[]
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getMethod(): string
+	public function getMethods(): array
 	{
-		return $this->method;
+		return $this->methods;
 	}
 
 	/**
@@ -290,17 +290,17 @@ class Route implements \Serializable
 	}
 
 	/**
-	 * Set the HTTP method this route supports
+	 * Set the HTTP methods this route supports
 	 *
-	 * @param   string  $method  The HTTP method this route supports
+	 * @param   array  $methods  The HTTP methods this route supports
 	 *
 	 * @return  $this
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function setMethod(string $method): self
+	public function setMethods(array $methods): self
 	{
-		$this->method = strtoupper($method);
+		$this->methods = $this->methods = array_map('strtoupper', $methods);
 
 		return $this;
 	}
@@ -388,7 +388,7 @@ class Route implements \Serializable
 			[
 				'controller'     => $controller,
 				'defaults'       => $this->getDefaults(),
-				'method'         => $this->getMethod(),
+				'methods'        => $this->getMethods(),
 				'pattern'        => $this->getPattern(),
 				'regex'          => $this->getRegex(),
 				'routeVariables' => $this->getRouteVariables(),
@@ -412,7 +412,7 @@ class Route implements \Serializable
 		list (
 			$this->controller,
 			$this->defaults,
-			$this->method,
+			$this->methods,
 			$this->pattern,
 			$this->regex,
 			$this->routeVariables,

--- a/src/Router.php
+++ b/src/Router.php
@@ -71,78 +71,6 @@ class Router implements \Serializable
 	}
 
 	/**
-	 * Parse the given pattern to extract the named variables and build a proper regular expression for use when parsing the routes.
-	 *
-	 * @param   string  $pattern  The route pattern to use for matching.
-	 * @param   array   $rules    An array of regex rules keyed using the named route variables.
-	 *
-	 * @return  array
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	protected function buildRegexAndVarList(string $pattern, array $rules = []): array
-	{
-		// Sanitize and explode the pattern.
-		$pattern = explode('/', trim(parse_url((string) $pattern, PHP_URL_PATH), ' /'));
-
-		// Prepare the route variables
-		$vars = [];
-
-		// Initialize regular expression
-		$regex = [];
-
-		// Loop on each segment
-		foreach ($pattern as $segment)
-		{
-			if ($segment == '*')
-			{
-				// Match a splat with no variable.
-				$regex[] = '.*';
-			}
-			elseif (isset($segment[0]) && $segment[0] == '*')
-			{
-				// Match a splat and capture the data to a named variable.
-				$vars[] = substr($segment, 1);
-				$regex[] = '(.*)';
-			}
-			elseif (isset($segment[0]) && $segment[0] == '\\' && $segment[1] == '*')
-			{
-				// Match an escaped splat segment.
-				$regex[] = '\*' . preg_quote(substr($segment, 2));
-			}
-			elseif ($segment == ':')
-			{
-				// Match an unnamed variable without capture.
-				$regex[] = '([^/]*)';
-			}
-			elseif (isset($segment[0]) && $segment[0] == ':')
-			{
-				// Match a named variable and capture the data.
-				$varName = substr($segment, 1);
-				$vars[] = $varName;
-
-				// Use the regex in the rules array if it has been defined.
-				$regex[] = array_key_exists($varName, $rules) ? '(' . $rules[$varName] . ')' : '([^/]*)';
-			}
-			elseif (isset($segment[0]) && $segment[0] == '\\' && $segment[1] == ':')
-			{
-				// Match a segment with an escaped variable character prefix.
-				$regex[] = preg_quote(substr($segment, 1));
-			}
-			else
-			{
-				// Match the standard segment.
-				$regex[] = preg_quote($segment);
-			}
-		}
-
-		return [
-			chr(1) . '^' . implode('/', $regex) . '$' . chr(1),
-			$vars,
-		];
-	}
-
-	/**
 	 * Add an array of route maps to the router.  If the pattern already exists it will be overwritten.
 	 *
 	 * @param   array  $routes  A list of route maps to add to the router as $pattern => $controller.
@@ -179,9 +107,7 @@ class Router implements \Serializable
 				$rules    = $route['rules'] ?? [];
 				$method   = $route['method'] ?? 'GET';
 
-				list($regex, $vars) = $this->buildRegexAndVarList($route['pattern'], $rules);
-
-				$this->addRoute(new Route($method, $regex, $route['controller'], $vars, $defaults));
+				$this->addRoute(new Route($method, $route['pattern'], $route['controller'], $rules, $defaults));
 			}
 		}
 
@@ -276,9 +202,7 @@ class Router implements \Serializable
 	 */
 	public function get(string $pattern, $controller, array $rules = [], array $defaults = [])
 	{
-		list($regex, $vars) = $this->buildRegexAndVarList($pattern, $rules);
-
-		return $this->addRoute(new Route('GET', $regex, $controller, $vars, $defaults));
+		return $this->addRoute(new Route('GET', $pattern, $controller, $rules, $defaults));
 	}
 
 	/**
@@ -295,9 +219,7 @@ class Router implements \Serializable
 	 */
 	public function post(string $pattern, $controller, array $rules = [], array $defaults = [])
 	{
-		list($regex, $vars) = $this->buildRegexAndVarList($pattern, $rules);
-
-		return $this->addRoute(new Route('POST', $regex, $controller, $vars, $defaults));
+		return $this->addRoute(new Route('POST', $pattern, $controller, $rules, $defaults));
 	}
 
 	/**
@@ -314,9 +236,7 @@ class Router implements \Serializable
 	 */
 	public function put(string $pattern, $controller, array $rules = [], array $defaults = [])
 	{
-		list($regex, $vars) = $this->buildRegexAndVarList($pattern, $rules);
-
-		return $this->addRoute(new Route('PUT', $regex, $controller, $vars, $defaults));
+		return $this->addRoute(new Route('PUT', $pattern, $controller, $rules, $defaults));
 	}
 
 	/**
@@ -333,9 +253,7 @@ class Router implements \Serializable
 	 */
 	public function delete(string $pattern, $controller, array $rules = [], array $defaults = [])
 	{
-		list($regex, $vars) = $this->buildRegexAndVarList($pattern, $rules);
-
-		return $this->addRoute(new Route('DELETE', $regex, $controller, $vars, $defaults));
+		return $this->addRoute(new Route('DELETE', $pattern, $controller, $rules, $defaults));
 	}
 
 	/**
@@ -352,9 +270,7 @@ class Router implements \Serializable
 	 */
 	public function head(string $pattern, $controller, array $rules = [], array $defaults = [])
 	{
-		list($regex, $vars) = $this->buildRegexAndVarList($pattern, $rules);
-
-		return $this->addRoute(new Route('HEAD', $regex, $controller, $vars, $defaults));
+		return $this->addRoute(new Route('HEAD', $pattern, $controller, $rules, $defaults));
 	}
 
 	/**
@@ -371,9 +287,7 @@ class Router implements \Serializable
 	 */
 	public function options(string $pattern, $controller, array $rules = [], array $defaults = [])
 	{
-		list($regex, $vars) = $this->buildRegexAndVarList($pattern, $rules);
-
-		return $this->addRoute(new Route('OPTIONS', $regex, $controller, $vars, $defaults));
+		return $this->addRoute(new Route('OPTIONS', $pattern, $controller, $rules, $defaults));
 	}
 
 	/**
@@ -390,9 +304,7 @@ class Router implements \Serializable
 	 */
 	public function trace(string $pattern, $controller, array $rules = [], array $defaults = [])
 	{
-		list($regex, $vars) = $this->buildRegexAndVarList($pattern, $rules);
-
-		return $this->addRoute(new Route('TRACE', $regex, $controller, $vars, $defaults));
+		return $this->addRoute(new Route('TRACE', $pattern, $controller, $rules, $defaults));
 	}
 
 	/**
@@ -409,9 +321,7 @@ class Router implements \Serializable
 	 */
 	public function patch(string $pattern, $controller, array $rules = [], array $defaults = [])
 	{
-		list($regex, $vars) = $this->buildRegexAndVarList($pattern, $rules);
-
-		return $this->addRoute(new Route('PATCH', $regex, $controller, $vars, $defaults));
+		return $this->addRoute(new Route('PATCH', $pattern, $controller, $rules, $defaults));
 	}
 
 	/**
@@ -428,11 +338,9 @@ class Router implements \Serializable
 	 */
 	public function all(string $pattern, $controller, array $rules = [], array $defaults = [])
 	{
-		list($regex, $vars) = $this->buildRegexAndVarList($pattern, $rules);
-
 		foreach ($this->routes as $method => $routes)
 		{
-			$this->addRoute(new Route($method, $regex, $controller, $vars, $defaults));
+			$this->addRoute(new Route($method, $pattern, $controller, $rules, $defaults));
 		}
 
 		return $this;

--- a/src/Router.php
+++ b/src/Router.php
@@ -226,7 +226,7 @@ class Router implements \Serializable
 					$vars[$var] = $matches[$i + 1];
 				}
 
-				return new ResolvedRoute($rule->getController(), $vars);
+				return new ResolvedRoute($rule->getController(), $vars, $route);
 			}
 		}
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -198,7 +198,7 @@ class Router implements \Serializable
 	 * @param   string  $route   The route string for which to find and execute a controller.
 	 * @param   string  $method  Request method to match. One of GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE or PATCH
 	 *
-	 * @return  array   An array containing the controller and the matched variables.
+	 * @return  ResolvedRoute
 	 *
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
@@ -229,10 +229,7 @@ class Router implements \Serializable
 					$vars[$var] = $matches[$i + 1];
 				}
 
-				return [
-					'controller' => $rule['controller'],
-					'vars'       => $vars
-				];
+				return new ResolvedRoute($rule['controller'], $vars);
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes

Changes the router to work with data objects versus arrays to try and create a better defined structure of our API and its data.

There is a B/C break in the Router's `parseRoute` method, changing from an array return to a `ResolvedRoute` object (we might be able to implement `ArrayAccess` here and buffer a large part of the break as far as working with the data goes, but if someone were passing the return into a typehinted method it'd be broken).

The new `addRoute` method is changed to receive a configured `Route` object instead of the individual arguments making it up, suitable for highly advanced cases where someone may elect to build route internals on their own.  The method helpers continue to receive individual arguments and will build the `Route` object on their own.

The `addRoutes` method is adjusted to support receiving both `Route` objects and the separated array arguments as before.

### Testing Instructions

For the most part, the public facing API still functions the same, minus the B/C breaks in the `addRoute` signature (which is new in 2.0 so not really B/C) and the `parseRoute` return.

### Documentation Changes Required

B/C break in `parseRoute`