### PR TITLE
[PHP8.4] Deprecate implicitly nullable parameter types

### DIFF
--- a/src/Exception/MethodNotAllowedException.php
+++ b/src/Exception/MethodNotAllowedException.php
@@ -32,7 +32,7 @@ class MethodNotAllowedException extends \RuntimeException
      * @param   integer      $code            The Exception code.
      * @param   ?\Exception  $previous        The previous throwable used for the exception chaining.
      */
-    public function __construct(array $allowedMethods, $message = null, $code = 405, \Exception $previous = null)
+    public function __construct(array $allowedMethods, $message = null, $code = 405, ?\Exception $previous = null)
     {
         $this->allowedMethods = array_map('strtoupper', $allowedMethods);
 


### PR DESCRIPTION
### Summary of Changes

updates for [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

### Testing Instructions

code review

### Documentation Changes Required

no